### PR TITLE
Dockerize

### DIFF
--- a/Docker/chatapp/package.json
+++ b/Docker/chatapp/package.json
@@ -4,7 +4,7 @@
   "description": "test react app",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --hot &",
+    "start": "webpack-dev-server --hot --inline --host 0.0.0.0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/Docker/message-service/server/server.js
+++ b/Docker/message-service/server/server.js
@@ -31,4 +31,4 @@ app.get("/listen/socket.io", function(req, res) {
   res.json(poller.poll(require('socket.io')(server, {path: '/listen/socket.io'})));
 });
 
-server.listen(8082, "localhost");
+server.listen(8082, "0.0.0.0");


### PR DESCRIPTION
Fixes a couple of issues that arise when dockerizing:

- both server and chatapp must listen on 0.0.0.0
- webpack-dev-server needs --inline for it to play nice with the interactive terminal

<img width="1029" alt="screen shot 2018-01-31 at 9 52 26 pm" src="https://user-images.githubusercontent.com/6052904/35658824-2d115e06-06d1-11e8-94bd-0dd39958510b.png">
<img width="284" alt="screen shot 2018-01-31 at 9 53 04 pm" src="https://user-images.githubusercontent.com/6052904/35658825-2d1db35e-06d1-11e8-93fb-075602ec1bea.png">
